### PR TITLE
Count Repetitions

### DIFF
--- a/other/clrs/07/01/02.py
+++ b/other/clrs/07/01/02.py
@@ -10,13 +10,15 @@ def partition(numbers, start = 0, end = None):
 
         if value == pivot_value:
             repetitions += 1
+        else:
+            repetitions = 0;
 
         if value <= pivot_value:
             numbers[pivot], numbers[i] = numbers[i], numbers[pivot]
             pivot += 1
 
     numbers[pivot], numbers[last] = numbers[last], numbers[pivot]
-    return pivot - repetitions // 2
+    return (pivot + 1) - repetitions // 2
 
 def quicksort(numbers, start = 0, end = None):
     end = end if end else len(numbers)


### PR DESCRIPTION
We should count only LAST repetitions. If we have repetitions of some first elements and then goes different, the "pivot - repetitions // 2" returns wrong value. For example:
we have:
11 11 11 11 8 7 4 21 26 11
after line 18 we have:
11 11 11 11 8 7 4 [11] 21 26
if we counted repetitions by your algorythm the function returns q=5 A[5] = 8, 8 > 7. We broke the main rule.