### PR TITLE
fix(problem 2.3): fix inner loop variable boundaries

### DIFF
--- a/other/clrs/02/problems/03.markdown
+++ b/other/clrs/02/problems/03.markdown
@@ -45,7 +45,7 @@ We assume that we have no exponentiation in the language. Thus:
     y = 0
     for i = 0 to n
         m = 1
-        for k = 1 to n
+        for k = 1 to i
             m = m·x
         y = y + aᵢ·m
 


### PR DESCRIPTION
The current inner loop boundary makes the `x` term the same for every coefficient when the amount of times we need to multiply by x really depends on how many coefficients (i) we've looked at.
