### PR TITLE
Fix two small typos in exercise C.3-3

### DIFF
--- a/other/clrs/C/03/03.markdown
+++ b/other/clrs/C/03/03.markdown
@@ -8,9 +8,9 @@
 Here are the probabilities:
 
 $$ \Pr\\{X = 3\\} = 1/216 \\\\
-   \Pr\\{X = 2\\} = 3(6/216) - 3(1/126) = 5/216 \\\\
+   \Pr\\{X = 2\\} = 3(6/216) - 3(1/126) = 15/216 \\\\
    \Pr\\{X = 1\\} = 3(36/216) - 3(11/216) = 75/216 \\\\
-   \Pr\\{X = 1\\} = 125/216 $$
+   \Pr\\{X = 0\\} = 125/216 $$
 
 (There are 36 ways that a specific die is $k$, but in 10 of them one of the
 other die is also $k$ and in one of them both are).


### PR DESCRIPTION
Pr{X = 1} is listed twice when describing the probability density
function. The second occurrence is meant to be Pr{X = 0}.

Also, the Pr{X = 2} is given as 3(6/216) - 3(1/126) = 5/216, where
5/216 should actually be 15/216.

In both cases, the correct values already appear in the
"calculation" section near the bottom.