### PR TITLE
Fixed wrong algorithm

### DIFF
--- a/other/clrs/02/01/04.markdown
+++ b/other/clrs/02/01/04.markdown
@@ -24,8 +24,8 @@ Here is the pseudocode:
       C = new integer[A.length + 1]
 
       carry = 0
-      for i = 1 to A.length
-          C[i] = (A[i] + B[i] + carry) % 2  // remainder
+      for i = A.length downto 1
+          C[i+1] = (A[i] + B[i] + carry) % 2  // remainder
           carry = (A[i] + B[i] + carry) / 2 // quotient
       C[i] = carry
 


### PR DESCRIPTION
Your original algorithm is not correct. Binary addition works from right to left. Therefore, for loops starts at the rightmost digit, works its way towards left.

Python code:

a = [1,0,1,1,1]
b = [0,1,1,1,0]
c = [0,0,0,0,0,0]

carry = 0
for i in range(4,-1,-1):
    print i
    c[i+1] = (a[i] + b[i] + carry) % 2
    carry = (a[i] + b[i] +carry)/2
c[i] = carry

print c