### PR TITLE
Get MathJax.js via HTTPS instead of HTTP

### DIFF
--- a/other/clrs/build/views/layout.erb
+++ b/other/clrs/build/views/layout.erb
@@ -30,7 +30,7 @@
         "HTML-CSS": { availableFonts: ["TeX"] }
       });
     </script>
-    <script type="application/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+    <script type="application/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
   </head>
   <body>
     <div class="navbar navbar-inverse navbar-static-top">


### PR DESCRIPTION
ita.skanev.com is hosted on HTTPS, so loading JS from HTTP gets blocked.