### PR TITLE
fix clrs-07-01-02 solution bug

### DIFF
--- a/other/clrs/07/01/02.markdown
+++ b/other/clrs/07/01/02.markdown
@@ -5,5 +5,4 @@
 
 It returns $r$.
 
-We can modify `PARTITION` by counting the number of comparisons in which $A[j]
-= A[r]$ and then subtracting half that number from the pivot index.
+We can modify `PARTITION` by moving numbers smaller than the pivot to the leftmost and numbers equal to the pivot after the smaller group. At last we return the count of smaller group plus half of count the equal numbers.

--- a/other/clrs/07/01/02.py
+++ b/other/clrs/07/01/02.py
@@ -8,15 +8,17 @@ def partition(numbers, start = 0, end = None):
     for i in range(start, last):
         value = numbers[i]
 
-        if value == pivot_value:
-            repetitions += 1
-
-        if value <= pivot_value:
-            numbers[pivot], numbers[i] = numbers[i], numbers[pivot]
+        if value < pivot_value:
+            numbers[pivot+repetitions], numbers[i] = numbers[i], numbers[pivot+repetitions]
+            numbers[pivot+repetitions], numbers[pivot] = numbers[pivot], numbers[pivot+repetitions]
             pivot += 1
-
-    numbers[pivot], numbers[last] = numbers[last], numbers[pivot]
-    return pivot - repetitions // 2
+        elif value == pivot_value:
+            numbers[pivot+repetitions], numbers[i] = numbers[i], numbers[pivot+repetitions]
+            numbers[pivot+repetitions], numbers[pivot] = numbers[pivot], numbers[pivot+repetitions]
+            repetitions += 1
+	
+    numbers[pivot+repetitions], numbers[last] = numbers[last], numbers[pivot+repetitions]
+    return pivot + repetitions // 2
 
 def quicksort(numbers, start = 0, end = None):
     end = end if end else len(numbers)

--- a/other/clrs/07/01/02.test.py
+++ b/other/clrs/07/01/02.test.py
@@ -15,8 +15,9 @@ class PartitionTest(unittest.TestCase):
       self.assertEqual(numbers, [3, 5, 8, 7, 4, 2, 6, 11, 21, 13, 19, 12])
 
     def test_partition_with_repetition(self):
-      self.assertEqual(partition([2, 2, 2, 2, 2, 2]), 3)
-      self.assertEqual(partition([1, 2, 2, 2, 3, 2]), 3)
+      self.assertEqual(partition([2, 2, 2, 2, 2, 2]), 2)
+      self.assertEqual(partition([1, 2, 2, 2, 3, 2]), 2)
+      self.assertEqual(partition([5, 2, 4, 7, 5, 1, 5, 9, 5, 1, 10, 5]), 6)
 
     def test_quicksort(self):
       numbers  = [13, 19, 3, 5, 12, 8, 7, 4, 21, 2, 6, 11]


### PR DESCRIPTION
Thanks for your sharing solutions. 
There is a problem with your solution to the clrs-07-01-02. You can not simply count the numbers that equal to the pivot. Although it can produce the right answer when all numbers are equal. However, it is not a right partition algorithm!

Consider the test case: 
[5, 2, 4, 7, 5, 1, 5, 9, 5, 1, 10, 5] 

After your original partition it is:
[5, 2, 4, 5, 1, 5, 5, 1, 5, 9, 10, 7]
And the returned pivot index is 6. However, the larger part has a number 1. Obviously, it is not a proper partition algorithm.

I fix the problem by moving the smaller number to the leftmost, and the numbers equal to the pivot after the smaller group. So we can get the right answer to the same test case like:
[2, 4, 1, 1, 5, 5, 5, 5, 5, 9, 10, 7]
And the returned index is also 6.
